### PR TITLE
remove constant initialization to null

### DIFF
--- a/README-ZH.md
+++ b/README-ZH.md
@@ -40,7 +40,6 @@ val name = "Amit Shekhar"
 - Java
 
 ```java
-final String name = null;
 String otherName;
 otherName = null;
 ```
@@ -48,7 +47,6 @@ otherName = null;
 - Kotlin
 
 ```kotlin
-val name : String? = null
 var otherName : String?
 otherName = null
 ```

--- a/README.md
+++ b/README.md
@@ -45,7 +45,6 @@ val name = "Amit Shekhar"
 > Java
 
 ```java
-final String name = null;
 String otherName;
 otherName = null;
 ```
@@ -53,7 +52,6 @@ otherName = null;
 > Kotlin
 
 ```kotlin
-val name : String? = null
 var otherName : String?
 otherName = null
 ```


### PR DESCRIPTION
I massively appreciate cheat sheets like this, but I think initializing a constant to null could be removed to better effect.