### PR TITLE
Sub Heading name change- Logical Operators is changed to Bitwise Operators

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ log(message ?: "")
 ```
 
 ---
-## Logical Operators
+## Bitwise Operators
 > Java
 
 ```java


### PR DESCRIPTION
Bitwise Operators in Java is mistitled as Logical Operator. Change corrects the title.