### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,9 +91,9 @@ String message = "My name is: " + firstName + " " + lastName;
 > Kotlin
 
 ```kotlin
-val firstName = "Amit"
-val lastName = "Shekhar"
-val message = "My name is: $firstName $lastName"
+var firstName = "Amit"
+var lastName = "Shekhar"
+var message = "My name is: $firstName $lastName"
 ```
 
 ---


### PR DESCRIPTION
The Java examples are not final, so the Kotlin equivalents have to be var instead of val.