### PR TITLE
Use concise ternary operation syntax for Kotlin

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,11 +168,7 @@ log(message != null ? message : "");
 > Kotlin
 
 ```kotlin
-val text = if (x > 5) {
-    "x > 5"
-} else {
-    "x <= 5"
-}
+val text = if (x > 5) "x > 5" else "x <= 5"
 
 val message: String? = null
 log(message ?: "")


### PR DESCRIPTION
This way it is more concise, readable and similar to the Java example.