### PR TITLE
separated object keyword with backtick in Kotlin.

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,12 +234,13 @@ if (object instanceof Car) {
 > Kotlin
 
 ```kotlin
-if (object is Car) {
+// object is also keyword in kotlin so we can use ` backtick symbol to use keyword as name
+if (`object` is Car) {
 var car = object as Car
 }
 
 // if object is null
-var car = object as? Car // var car = object as Car?
+var car = `object` as? Car // var car = `object` as Car?
 ```
 
 ---
@@ -255,13 +256,13 @@ if (object instanceof Car) {
 > Kotlin
 
 ```kotlin
-if (object is Car) {
-   var car = object // smart casting
+if (`object` is Car) {
+   var car = `object` // smart casting
 }
 
 // if object is null
-if (object is Car?) {
-   var car = object // smart casting, car will be null
+if (`object` is Car?) {
+   var car = `object` // smart casting, car will be null
 }
 ```
 


### PR DESCRIPTION
separated object keyword with backtick in Kotlin.
Since object is keyword in kotlin so we should separated keyword with backtick in order to use as  name of variable or method and class extra.